### PR TITLE
Tweak migrations to fix issue migrating

### DIFF
--- a/mchp/schedule/migrations/0001_initial.py
+++ b/mchp/schedule/migrations/0001_initial.py
@@ -94,10 +94,6 @@ class Migration(migrations.Migration):
             bases=(models.Model,),
         ),
         migrations.AlterUniqueTogether(
-            name='section',
-            unique_together=set([('student', 'course', 'day')]),
-        ),
-        migrations.AlterUniqueTogether(
             name='schoolquicklink',
             unique_together=set([('domain', 'quick_link')]),
         ),

--- a/mchp/schedule/migrations/0002_section_student.py
+++ b/mchp/schedule/migrations/0002_section_student.py
@@ -18,4 +18,8 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(default=None, to='user_profile.Student', related_name='student_sections'),
             preserve_default=False,
         ),
+        migrations.AlterUniqueTogether(
+            name='section',
+            unique_together=set([('student', 'course', 'day')]),
+        ),
     ]


### PR DESCRIPTION
Since the `student` field in the `Section` model isn't created until the second migration, the alter statement for `unique_together` in the first migration errors out.
