### PR TITLE
Added calendar default color removal migration

### DIFF
--- a/mchp/calendar_mchp/migrations/0006_auto_20150814_0130.py
+++ b/mchp/calendar_mchp/migrations/0006_auto_20150814_0130.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('calendar_mchp', '0005_create_calendars_for_courses'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='classcalendar',
+            name='color',
+            field=models.CharField(blank=True, max_length=7),
+        ),
+    ]


### PR DESCRIPTION
@mitchellias I missed the migration when implementing automatic public calendar creation. The migration only removes default=#FFFFFF property, since colors are properly generated in the save method.
